### PR TITLE
Make underlined th background transparent

### DIFF
--- a/src/4-components/t1-tables/t1-style.scss
+++ b/src/4-components/t1-tables/t1-style.scss
@@ -64,7 +64,7 @@ table,
 			tr {
 				td,
 				th {
-					background-color: $act-colour__white;
+					background-color: transparent;
 					border: 1px solid $act-colour__grey;
 					border-left: 0px solid $act-colour__white;
 					border-radius: 0px !important;


### PR DESCRIPTION
Changed the background on the th element with class __underlined to be transparent instead of white to make it looks better when the table is used on a background that's not white.