### PR TITLE
Add 24px min-height to links in sidebar nav

### DIFF
--- a/src/4-components/w1-wayfinding/w13-sidebar/w13-style.scss
+++ b/src/4-components/w1-wayfinding/w13-sidebar/w13-style.scss
@@ -17,6 +17,7 @@
 		font-size: $act-font-size__desktop-h5;
 		width: 100%;
 		a {
+			min-height: 24px;
 			&:hover,
 			&:focus {
 				text-decoration: underline;


### PR DESCRIPTION
Added a 24px min-height to sidebar nav links (act-sidebar__item a) because some of them are getting flagged for accessibility for being lower than the minimum size for interactive elements.